### PR TITLE
Increase allowed max lines per function to 35

### DIFF
--- a/lib/core/stylistic-issues.js
+++ b/lib/core/stylistic-issues.js
@@ -122,7 +122,7 @@ module.exports = {
     }],
 
     'max-lines-per-function': ['error', {
-      max: 20,
+      max: 35,
       skipBlankLines: true,
       skipComments: true,
       IIFEs: true,


### PR DESCRIPTION
Signed-off-by: Henri Beck <henribeck.dev@gmail.com>